### PR TITLE
Fixed bug where RedisStore publishers were shared

### DIFF
--- a/examples/chatserver/tests/chatclient.py
+++ b/examples/chatserver/tests/chatclient.py
@@ -151,3 +151,9 @@ class WebsocketTests(LiveServerTestCase):
         header = ['Sec-WebSocket-Version: 6']  # Version 6 is not supported
         ws = create_connection(websocket_url, header=header)
         self.assertFalse(ws.connected)
+
+    def test_defining_multiple_publishers(self):
+        pub1 = RedisPublisher(facility=self.facility, broadcast=True)
+        self.assertEqual(pub1._publishers, set(['ws4redis:broadcast:foobar']))
+        pub2 = RedisPublisher(facility=self.facility, users='admin')
+        self.assertEqual(pub2._publishers, set(['ws4redis:user:admin:foobar']))

--- a/ws4redis/redis_store.py
+++ b/ws4redis/redis_store.py
@@ -7,9 +7,9 @@ class RedisStore(object):
     Abstract base class to control publishing  and subscription for messages to and from the Redis datastore.
     """
     _expire = settings.WS4REDIS_EXPIRE
-    _publishers = set()
 
     def __init__(self, connection):
+        self._publishers = set()
         self._connection = connection
 
     def publish_message(self, message, expire=None):


### PR DESCRIPTION
I was using multiple publishers and discovered that my user publisher was also broadcasting, and that the RedisPublisher's _publishers attribute was being modified when I defined a publisher. The following fixed the problem.
