### PR TITLE
use _connection.setex() for expiring redis values

### DIFF
--- a/ws4redis/redis_store.py
+++ b/ws4redis/redis_store.py
@@ -76,7 +76,7 @@ class RedisStore(object):
             for channel in self._publishers:
                 self._connection.publish(channel, message)
                 if expire > 0:
-                    self._connection.set(channel, message, ex=expire)
+                    self._connection.setex(channel, expire, message)
 
     def get_prefix(self):
         """


### PR DESCRIPTION
As discussed in #25:

in ws4redis.redis_store.RedisStore in publish_message, change 

``` python
self._connection.set(channel, message, ex=expire)
```

to

``` python
self._connection.setex(channel, expire, message)
```

the redis `SET` command does not take a 3rd argument. What I believe was meant was to set a value that expires after a number of seconds, which is the redis `SETEX`command. The py-redis `setex` method is called like `setex(name, time, value)`.

This resolves the "Wrong number of argument for 'set'" error.
