### PR TITLE
Fix for code snippet in running.rst

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -122,7 +122,7 @@ and one for the WebSocket loop, say ``wsgi_websocket.py``
 .. code-block:: python
 
 	import os
-	import gevent.monkey
+	import gevent.socket
 	import redis.connection
 	redis.connection.socket = gevent.socket
 	os.environ.update(DJANGO_SETTINGS_MODULE='my_app.settings')


### PR DESCRIPTION
Previously this raised

```
Traceback (most recent call last):
  File "mixim/wsgi_websockets.py", line 4, in <module>
    redis.connection.socket = gevent.socket
AttributeError: 'module' object has no attribute 'socket'
```
