### PR TITLE
Add request to RedisPublisher to use SELF

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -145,7 +145,7 @@ If the message shall be send to the currently logged in user, then you may use t
 
 	from ws4redis.redis_store import SELF
 
-	redis_publisher = RedisPublisher(facility='foobar', users=[SELF])
+	redis_publisher = RedisPublisher(facility='foobar', users=[SELF], request=request)
 
 Subscribe to Group Notification
 -------------------------------


### PR DESCRIPTION
The _wrap_user code that converts SELF to the active user needs the request instance. This can be passed through the RedisPublisher constructor.

```
def _wrap_users(users, request):
    ...
    for u in users:
        if u is SELF and request and request.user and request.user.is_authenticated():
            result.add(request.user.get_username())
    ....
```