### PR TITLE
Exponential backoff in websocket connection

### DIFF
--- a/ws4redis/static/js/ws4redis.js
+++ b/ws4redis/static/js/ws4redis.js
@@ -58,8 +58,8 @@ function WS4Redis(options, $) {
 		if (!timer) {
 			// try to reconnect
 			var interval = generateInteval(attempts);
-			console.log("will try to reconnect in " + interval + "ms");
 			timer = setTimeout(function() {
+				attempts++;
 				connect(ws.url);
 			}, interval);
 		}
@@ -80,6 +80,10 @@ function WS4Redis(options, $) {
 	}
 
 	// this code is borrowed from http://blog.johnryding.com/post/78544969349/
+	//
+	// Generate an interval that is randomly between 0 and 2^k - 1, where k is
+	// the number of connection attmpts, with a maximum interval of 30 seconds,
+	// so it starts at 0 - 1 seconds and maxes out at 0 - 30 seconds
 	function generateInteval (k) {
 		var maxInterval = (Math.pow(2, k) - 1) * 1000;
 


### PR DESCRIPTION
Based on the example in this blog post: http://blog.johnryding.com/post/78544969349/how-to-reconnect-web-sockets-in-a-realtime-web-app this patch updates the reconnect logic to use exponential backoff with a random component.

This is intended to prevent a "thundering heard" problem if the server goes down. If all the clients are using the same reconnect interval, they'll all attempt to reconnect at the same time. We mitigate this by using the random component.

The original backoff was from 0.5s to 5s in 0.5s steps. The new backoff is randomly chosen from 0 - 1s ramping up exponentially (2^k-1 where k is the number of failed attempts) to 0 - 30s. This is a bit less aggressive, so you might prefer other timings. The timings I used are based off that blog post.

It would certainly be possible to apply the random component to a linear backoff (like the original), though exponential backoff seems to be more widely recommended.
