### PR TITLE
Connection status callback

### DIFF
--- a/ws4redis/static/js/ws4redis.js
+++ b/ws4redis/static/js/ws4redis.js
@@ -12,7 +12,7 @@ function WS4Redis(options, $) {
 	if ($ === undefined)
 		$ = jQuery;
 	opts = $.extend({ heartbeat_msg: null }, options);
-	if(opts.status_callback && typeof opts.status_callback === 'function')
+	if (opts.status_callback && typeof opts.status_callback === 'function')
 		status_callback = opts.status_callback;
 	connect(opts.uri);
 


### PR DESCRIPTION
This patch adds an optional "status_callback" parameter to the connection options. This callback is called with a single boolean parameter indicating the connection status only when the state changes (i.e. it does not repeatedly fire with "false" when a connection attempt fails).

If your code relies on the websocket connection for major functionality, this provides a means to give feedback to the user and/or client code if the connection is lost. I'm open to other ideas to achieve this goal, but this seemed like the simplest and most flexible way to get there.
