### PR TITLE
Fixed unbound memory usage by killing redis subscriptions

### DIFF
--- a/ws4redis/subscriber.py
+++ b/ws4redis/subscriber.py
@@ -64,3 +64,15 @@ class RedisSubscriber(RedisStore):
         on the message queue.
         """
         return self._subscription.connection and self._subscription.connection._sock.fileno()
+
+    #Kai Peng
+    def unsubscribe_pubsub_channels(self):
+        """
+        New implementation to free up Redis subscriptions when websockets close. This prevents
+        memory sap when Redis Output Buffer and Output Lists build when websockets are abandoned.
+        """
+        print 'Unsubscribing from pubsubs:'
+        for key in self.message_channels:
+            print 'Unsub from :', key
+            self._subscription.unsubscribe(key)
+            #Kai Peng

--- a/ws4redis/wsgi_server.py
+++ b/ws4redis/wsgi_server.py
@@ -116,6 +116,10 @@ class WebsocketWSGIServer(object):
             response = http.HttpResponse()
         if websocket:
             websocket.close(code=1001, message='Websocket Closed')
+        #Kai Peng - We need to close Redis Subscriptions to prevent unbound memory consumption upon websocket closing
+        if subscriber:
+            subscriber.unsubscribe_pubsub_channels()
+        #Kai Peng
         if hasattr(start_response, 'im_self') and not start_response.im_self.headers_sent:
             logger.warning('Staring late response on websocket')
             status_text = STATUS_CODE_TEXT.get(response.status_code, 'UNKNOWN STATUS CODE')


### PR DESCRIPTION
Fixed unbound memory usage by killing redis subscriptions when websockets are closed and abandoned by clients.