### PR TITLE
Cleanup redis connections when websockets disconnect.

### DIFF
--- a/ws4redis/subscriber.py
+++ b/ws4redis/subscriber.py
@@ -64,3 +64,13 @@ class RedisSubscriber(RedisStore):
         on the message queue.
         """
         return self._subscription.connection and self._subscription.connection._sock.fileno()
+
+    def release(self):
+        """
+        New implementation to free up Redis subscriptions when websockets close. This prevents
+        memory sap when Redis Output Buffer and Output Lists build when websockets are abandoned.
+        """
+        if self._subscription and self._subscription.subscribed:
+            self._subscription.unsubscribe()
+            self._subscription.reset()
+

--- a/ws4redis/wsgi_server.py
+++ b/ws4redis/wsgi_server.py
@@ -120,8 +120,10 @@ class WebsocketWSGIServer(object):
             response = http.HttpResponseServerError(content=excpt)
         else:
             response = http.HttpResponse()
-        if websocket:
-            websocket.close(code=1001, message='Websocket Closed')
+        finally:
+            subscriber.release()
+            if websocket:
+                websocket.close(code=1001, message='Websocket Closed')
         if hasattr(start_response, 'im_self') and not start_response.im_self.headers_sent:
             logger.warning('Staring late response on websocket')
             status_text = STATUS_CODE_TEXT.get(response.status_code, 'UNKNOWN STATUS CODE')


### PR DESCRIPTION
Previously the redis subscriber wouldn't be closed or return to the
connection pool on websocket disconnect.  When running a few load tests
(each eg. 1000 connections) after another, we noticed that the later
load tests had more failures due to too many file handles.

The StrictRedis would release the connection on __del__ which is
fine with low churn, as the garbage collector would eventually close
the socket.  But to pro-actively close unneeded sockets, we must
explicitly release them ourselves.

This code is my own, but I was inspired by the pull request from
https://github.com/kaipeng/django-websocket-redis