### PR TITLE
Return the proper headers on errors before WebSocket handshake.

### DIFF
--- a/ws4redis/wsgi_server.py
+++ b/ws4redis/wsgi_server.py
@@ -122,10 +122,10 @@ class WebsocketWSGIServer(object):
             response = http.HttpResponse()
         if websocket:
             websocket.close(code=1001, message='Websocket Closed')
-        if hasattr(start_response, 'im_self') and not start_response.im_self.headers_sent:
-            logger.warning('Staring late response on websocket')
+        else:
+            logger.warning('Starting late response on websocket')
             status_text = STATUS_CODE_TEXT.get(response.status_code, 'UNKNOWN STATUS CODE')
             status = '{0} {1}'.format(response.status_code, status_text)
             start_response(force_str(status), response._headers.values())
-        logger.info('Finish long living response with status code: '.format(response.status_code))
+            logger.info('Finish non-websocket response with status code: {}'.format(response.status_code))
         return response


### PR DESCRIPTION
Before when there was, for example, a PermissionDenied response in
WS4REDIS_PROCESS_REQUEST, the response would only be the text of the
exception, without the standard HTTP headers. At least with uwsgi.
When proxying uwsgi through nginx this lead to problems, as nginx
didn't pass the response with missing headers onto the client.
Now, this is safe in a production environment.