### PR TITLE
Work in progress Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,8 @@ setup(
         'wsaccel': ['wsaccel>=0.6.2'],
         'django-redis-sessions': ['django-redis-sessions>=0.4.0'],
     },
+    dependency_links = [
+        'git+https://github.com/gevent/gevent.git@1.0.2#egg=gevent-1.0.2',
+    ],
     zip_safe=False,
 )

--- a/stress-tests/test_uwsgi_gevent.py
+++ b/stress-tests/test_uwsgi_gevent.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 # run this test against an instance of uwsgi for websockets
+from __future__ import print_function
 from nose import tools
 import gevent
 from gevent import monkey
@@ -12,7 +13,7 @@ def test_simple():
         ws = create_connection(closure['websocket_url'])
         assert ws.connected
         result = ws.recv()
-        print '+',
+        print('+', end='')
         tools.eq_(result, 'Hello, World')
         ws.close()
         tools.eq_(ws.connected, False)

--- a/ws4redis/redis_store.py
+++ b/ws4redis/redis_store.py
@@ -66,6 +66,7 @@ class RedisMessage(six.binary_type):
     def __new__(cls, value):
         if isinstance(value, six.string_types):
             if value != settings.WS4REDIS_HEARTBEAT:
+                value = value.encode('utf-8')
                 return six.binary_type.__new__(cls, value)
         elif isinstance(value, list):
             if len(value) >= 2 and value[0] == 'message':

--- a/ws4redis/redis_store.py
+++ b/ws4redis/redis_store.py
@@ -122,7 +122,7 @@ class RedisStore(object):
             warnings.warn('Wrap groups=True into a list or tuple using SELF', DeprecationWarning)
             channels.extend('{prefix}group:{0}:{facility}'.format(g, prefix=prefix, facility=facility)
                             for g in request.session.get('ws4redis:memberof', []))
-        elif isinstance(groups, basestring):
+        elif isinstance(groups, str):
             # message is delivered to the named group
             warnings.warn('Wrap a single group into a list or tuple', DeprecationWarning)
             channels.append('{prefix}group:{0}:{facility}'.format(groups, prefix=prefix, facility=facility))
@@ -138,7 +138,7 @@ class RedisStore(object):
             # message is delivered to browser instances of the currently logged in user
             warnings.warn('Wrap users=True into a list or tuple using SELF', DeprecationWarning)
             channels.append('{prefix}user:{0}:{facility}'.format(request.user.get_username(), prefix=prefix, facility=facility))
-        elif isinstance(users, basestring):
+        elif isinstance(users, str):
             # message is delivered to the named user
             warnings.warn('Wrap a single user into a list or tuple', DeprecationWarning)
             channels.append('{prefix}user:{0}:{facility}'.format(users, prefix=prefix, facility=facility))
@@ -154,7 +154,7 @@ class RedisStore(object):
             # message is delivered to browser instances owning the current session
             warnings.warn('Wrap a single session key into a list or tuple using SELF', DeprecationWarning)
             channels.append('{prefix}session:{0}:{facility}'.format(request.session.session_key, prefix=prefix, facility=facility))
-        elif isinstance(sessions, basestring):
+        elif isinstance(sessions, str):
             # message is delivered to the named user
             warnings.warn('Wrap a single session key into a list or tuple', DeprecationWarning)
             channels.append('{prefix}session:{0}:{facility}'.format(sessions, prefix=prefix, facility=facility))

--- a/ws4redis/utf8validator.py
+++ b/ws4redis/utf8validator.py
@@ -114,7 +114,7 @@ except:
 
             l = len(ba)
 
-            for i in xrange(l):
+            for i in range(l):
                 ## optimized version of decode(), since we are not interested in actual code points
 
                 self.state = Utf8Validator.UTF8VALIDATOR_DFA[256 + (self.state << 4) + Utf8Validator.UTF8VALIDATOR_DFA[ord(ba[i])]]

--- a/ws4redis/uwsgi_runserver.py
+++ b/ws4redis/uwsgi_runserver.py
@@ -13,7 +13,7 @@ class uWSGIWebsocket(object):
         """Return the file descriptor for the given websocket"""
         try:
             return uwsgi.connection_fd()
-        except IOError, e:
+        except IOError as e:
             self.close()
             raise WebSocketError(e)
 
@@ -26,7 +26,7 @@ class uWSGIWebsocket(object):
             raise WebSocketError("Connection is already closed")
         try:
             return uwsgi.websocket_recv_nb()
-        except IOError, e:
+        except IOError as e:
             self.close()
             raise WebSocketError(e)
 
@@ -39,7 +39,7 @@ class uWSGIWebsocket(object):
     def send(self, message, binary=None):
         try:
             uwsgi.websocket_send(message)
-        except IOError, e:
+        except IOError as e:
             self.close()
             raise WebSocketError(e)
 

--- a/ws4redis/websocket.py
+++ b/ws4redis/websocket.py
@@ -305,7 +305,7 @@ class Header(object):
     def mask_payload(self, payload):
         payload = bytearray(payload)
         mask = bytearray(self.mask)
-        for i in xrange(self.length):
+        for i in range(self.length):
             payload[i] ^= mask[i % 4]
         return str(payload)
 

--- a/ws4redis/websocket.py
+++ b/ws4redis/websocket.py
@@ -87,7 +87,7 @@ class WebSocket(object):
         :param payload: The bytestring payload associated with the close frame.
         """
         if not payload:
-            self.close(1000, None)
+            self.close(1000, '')
             return
         if len(payload) < 2:
             raise WebSocketError('Invalid close frame: {0} {1}'.format(header, payload))

--- a/ws4redis/websocket.py
+++ b/ws4redis/websocket.py
@@ -91,7 +91,7 @@ class WebSocket(object):
             return
         if len(payload) < 2:
             raise WebSocketError('Invalid close frame: {0} {1}'.format(header, payload))
-        code = struct.unpack('!H', str(payload[:2]))[0]
+        code = struct.unpack('!H', payload[:2].encode('utf-8'))[0]
         payload = payload[2:]
         if payload:
             validator = Utf8Validator()
@@ -224,7 +224,7 @@ class WebSocket(object):
             message = self._encode_bytes(message)
         elif opcode == self.OPCODE_BINARY:
             message = six.binary_type(message)
-        header = Header.encode_header(True, opcode, '', len(message), 0)
+        header = Header.encode_header(True, opcode, '', len(message), 0).encode('utf-8')
         try:
             self.stream.write(header + message)
         except socket_error:

--- a/ws4redis/websocket.py
+++ b/ws4redis/websocket.py
@@ -37,7 +37,7 @@ class WebSocket(object):
         If the conversion fails, the socket will be closed.
         """
         if not bytestring:
-            return u''
+            return ''
         try:
             return bytestring.decode('utf-8')
         except UnicodeDecodeError:

--- a/ws4redis/wsgi_server.py
+++ b/ws4redis/wsgi_server.py
@@ -2,6 +2,7 @@
 import sys
 from redis import StrictRedis
 import django
+import collections
 if django.VERSION[:2] >= (1, 7):
     django.setup()
 from django.conf import settings
@@ -71,12 +72,12 @@ class WebsocketWSGIServer(object):
         try:
             self.assure_protocol_requirements(environ)
             request = WSGIRequest(environ)
-            if callable(private_settings.WS4REDIS_PROCESS_REQUEST):
+            if isinstance(private_settings.WS4REDIS_PROCESS_REQUEST, collections.Callable):
                 private_settings.WS4REDIS_PROCESS_REQUEST(request)
             else:
                 self.process_request(request)
             channels, echo_message = self.process_subscriptions(request)
-            if callable(private_settings.WS4REDIS_ALLOWED_CHANNELS):
+            if isinstance(private_settings.WS4REDIS_ALLOWED_CHANNELS, collections.Callable):
                 channels = list(private_settings.WS4REDIS_ALLOWED_CHANNELS(request, channels))
             websocket = self.upgrade_websocket(environ, start_response)
             logger.debug('Subscribed to channels: {0}'.format(', '.join(channels)))

--- a/ws4redis/wsgi_server.py
+++ b/ws4redis/wsgi_server.py
@@ -131,6 +131,6 @@ class WebsocketWSGIServer(object):
                 logger.warning('Starting late response on websocket')
                 status_text = STATUS_CODE_TEXT.get(response.status_code, 'UNKNOWN STATUS CODE')
                 status = '{0} {1}'.format(response.status_code, status_text)
-                start_response(force_str(status), response._headers.values())
+                start_response(force_str(status), list(response._headers.values()))
                 logger.info('Finish non-websocket response with status code: {}'.format(response.status_code))
         return response


### PR DESCRIPTION
No more runtime and syntax errors.

Currently getting the following when starting trying to load the example page in a browser.

```
[2015-05-07 23:42:43,382 websocket] DEBUG: Failed to write closing frame -> closing socket
[2015-05-07 23:42:43,382 websocket] DEBUG: Closed WebSocket
[2015-05-07 23:42:43,383 wsgi_server] WARNING: WebSocketError: Socket is dead
Traceback (most recent call last):
  File "/home/ben/PycharmProjects/django-websocket-redis/ws4redis/websocket.py", line 241, in send
    self.send_frame(message, opcode)
  File "/home/ben/PycharmProjects/django-websocket-redis/ws4redis/websocket.py", line 222, in send_frame
    raise WebSocketError("Connection is already closed")
ws4redis.exceptions.WebSocketError: Connection is already closed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ben/PycharmProjects/django-websocket-redis/ws4redis/wsgi_server.py", line 109, in __call__
    websocket.send(private_settings.WS4REDIS_HEARTBEAT)
  File "/home/ben/PycharmProjects/django-websocket-redis/ws4redis/websocket.py", line 243, in send
    raise WebSocketError("Socket is dead")
ws4redis.exceptions.WebSocketError: Socket is dead
```