### PR TITLE
Move persistent message handling to queue

### DIFF
--- a/ws4redis/publisher.py
+++ b/ws4redis/publisher.py
@@ -45,6 +45,6 @@ class RedisPublisher(RedisStore):
         if audience in ('broadcast', 'any',):
             channels.append('{prefix}broadcast:{facility}'.format(prefix=prefix, facility=facility))
         for channel in channels:
-            message = self._connection.get(channel)
+            message = self.get_persisted_message(channel)
             if message:
                 return message

--- a/ws4redis/redis_store.py
+++ b/ws4redis/redis_store.py
@@ -118,9 +118,11 @@ class RedisStore(object):
             if queue_value is None:
                 return None
             expire_time, message = queue_value.split(':', 1)
-            if expire_time < time.time():
-                self._connection.rpush(queue_value)
+            if float(expire_time) > time.time():
+                self._connection.rpush(channel, queue_value)
                 return message
+            elif expire_time == '0':
+                return None
 
     @staticmethod
     def get_prefix():

--- a/ws4redis/redis_store.py
+++ b/ws4redis/redis_store.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import six
+import time
+import math
 import warnings
 from ws4redis import settings
 
@@ -98,7 +100,27 @@ class RedisStore(object):
         for channel in self._publishers:
             self._connection.publish(channel, message)
             if expire > 0:
-                self._connection.setex(channel, expire, message)
+                self.persist_message(channel, message, expire)
+
+    def persist_message(self, channel, message, expire):
+        expire_time = math.ceil(time.time() + expire)
+        self._connection.rpush(channel, '{0}:{1}'.format(expire_time, message))
+        if self._connection.ttl(channel) < expire:
+            self._connection.expire(channel, expire)
+
+    def get_persisted_message(self, channel):
+        """
+        Returns a message which is not expired from the channel. There is no contract about
+        the order in which messages are returned.
+        """
+        while True:
+            queue_value = self._connection.lpop(channel)
+            if queue_value is None:
+                return None
+            expire_time, message = queue_value.split(':', 1)
+            if expire_time < time.time():
+                self._connection.rpush(queue_value)
+                return message
 
     @staticmethod
     def get_prefix():

--- a/ws4redis/subscriber.py
+++ b/ws4redis/subscriber.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import warnings
 from django.conf import settings
 from ws4redis.redis_store import RedisStore, SELF
 
@@ -48,15 +49,29 @@ class RedisSubscriber(RedisStore):
         for key in self._get_message_channels(request=request, facility=facility, **audience):
             self._subscription.subscribe(key)
 
+    def channel_connected(self, channel, request):
+        """
+        Hook for sub-classes. Called just before persisted messages are sent.
+        """
+        pass
+
     def send_persited_messages(self, websocket):
+        warnings.warn('Send_persisted_messages has been replaced by send_persistend messages', DeprecationWarning)
+        return self.send_persisted_messages(websocket)
+
+    def send_persisted_messages(self, websocket, request):
         """
         This method is called immediately after a websocket is openend by the client, so that
         persisted messages can be sent back to the client upon connection.
         """
         for channel in self._subscription.channels:
-            message = self._connection.get(channel)
-            if message:
-                websocket.send(message)
+            self.channel_connected(channel, request)
+            while True:
+                message = self.get_persisted_message(channel)
+                if message:
+                    websocket.send(message)
+                else:
+                    break
 
     def get_file_descriptor(self):
         """

--- a/ws4redis/subscriber.py
+++ b/ws4redis/subscriber.py
@@ -56,7 +56,7 @@ class RedisSubscriber(RedisStore):
         pass
 
     def send_persited_messages(self, websocket):
-        warnings.warn('Send_persisted_messages has been replaced by send_persistend messages', DeprecationWarning)
+        warnings.warn('send_persited_messages has been replaced by send_persisted messages', DeprecationWarning)
         return self.send_persisted_messages(websocket)
 
     def send_persisted_messages(self, websocket, request):
@@ -66,6 +66,8 @@ class RedisSubscriber(RedisStore):
         """
         for channel in self._subscription.channels:
             self.channel_connected(channel, request)
+
+            self._connection.rpush(channel, '{0}:{1}'.format(0, 'ws4redis_internal'))
             while True:
                 message = self.get_persisted_message(channel)
                 if message:

--- a/ws4redis/wsgi_server.py
+++ b/ws4redis/wsgi_server.py
@@ -93,7 +93,7 @@ class WebsocketWSGIServer(object):
             redis_fd = subscriber.get_file_descriptor()
             if redis_fd:
                 listening_fds.append(redis_fd)
-            subscriber.send_persited_messages(websocket)
+            subscriber.send_persisted_messages(websocket, request)
             recvmsg = None
             while websocket and not websocket.closed:
                 ready = self.select(listening_fds, [], [], 4.0)[0]


### PR DESCRIPTION
Persistent messages are now handled in a redis list, allowing multiple messages to be persisted for a given channel. `get_persisted_message` returns one member from the list.

Deprecate misspelled method `send_persited_messages`

Add `channel_connected` method to subscriber as a hook for custom subscribers to perform actions on connect.

re #102
