### PR TITLE
Change mutable default args in RedisStore._get_message_channels

### DIFF
--- a/ws4redis/redis_store.py
+++ b/ws4redis/redis_store.py
@@ -105,7 +105,7 @@ class RedisStore(object):
         return settings.WS4REDIS_PREFIX and '{0}:'.format(settings.WS4REDIS_PREFIX) or ''
 
     def _get_message_channels(self, request=None, facility='{facility}', broadcast=False,
-                              groups=[], users=[], sessions=[]):
+                              groups=(), users=(), sessions=()):
         prefix = self.get_prefix()
         channels = []
         if broadcast is True:


### PR DESCRIPTION
Mutable default args are generally a bad practice, although in this method they do not appear to be altered. I see no downside to using a tuple here instead of a list.