### PR TITLE
Added RedisMessage support for bytestrings

### DIFF
--- a/ws4redis/redis_store.py
+++ b/ws4redis/redis_store.py
@@ -69,6 +69,9 @@ class RedisMessage(six.binary_type):
                 if value != settings.WS4REDIS_HEARTBEAT:
                     value = value.encode()
                     return super(RedisMessage, cls).__new__(cls, value)
+            elif isinstance(value, bytes):
+                if value != settings.WS4REDIS_HEARTBEAT.encode():
+                    return super(RedisMessage, cls).__new__(cls, value)
             elif isinstance(value, list):
                 if len(value) >= 2 and value[0] == b'message':
                     return super(RedisMessage, cls).__new__(cls, value[2])


### PR DESCRIPTION
The `RedisMessage` wrapper only handles `str` or `list` types, but the websocket object's `receive` function returns bytestrings when running uwsgi as a standalone server with Python 3. All websocket messages sent are discarded. This pull request addresses that issue.