### PR TITLE
fix #135 for python2

### DIFF
--- a/ws4redis/websocket.py
+++ b/ws4redis/websocket.py
@@ -98,8 +98,7 @@ class WebSocket(object):
             raise WebSocketError('Invalid close frame: {0} {1}'.format(header, payload))
         rv = payload[:2]
         if six.PY2:
-            rv = str(rv)
-            code = struct.unpack('!H', rv[0])
+            code = struct.unpack('!H', str(rv))[0]
         else:
             code = struct.unpack('!H', bytes(rv))[0]
         payload = payload[2:]


### PR DESCRIPTION
Given that the previous code was returning a tuple while `close` expects a an int, I believe @roidelapluie 's fix should also be applied to python 2.
I guess it's just a part of the code we never hit before.
@jrief are you ok with this ?