### PR TITLE
Test with the right Django version ; Add and fix 1.9 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ branches:
     - master
 
 install:
-  - pip install -q Django==$DJANGO
   - pip install -r examples/requirements.txt
-  - python setup.py -q install
+  - pip install Django==$DJANGO
+  - python setup.py install
 
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,15 @@ env:
   - DJANGO=1.8.7 MIGRATE='./manage.py migrate'
   - DJANGO=1.9 MIGRATE='./manage.py migrate'
 
-matrix:
-  allow_failures:
-    - env: DJANGO=1.9 MIGRATE='./manage.py migrate'
-      python: 2.7
-    - env: DJANGO=1.9 MIGRATE='./manage.py migrate'
-      python: 3.3
-    - env: DJANGO=1.9 MIGRATE='./manage.py migrate'
-      python: 3.4
-
 branches:
   only:
     - master
+
+matrix:
+  exclude:
+    # Django 1.9 does not support python 3.3
+    - env: DJANGO=1.9 MIGRATE='./manage.py migrate'
+      python: 3.3
 
 install:
   - pip install -r examples/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,18 @@ python:
 env:
   - DJANGO=1.5.12 MIGRATE='true'
   - DJANGO=1.6.11 MIGRATE='true'
-  - DJANGO=1.7.7 MIGRATE='./manage.py migrate'
-  - DJANGO=1.8.5 MIGRATE='./manage.py migrate'
+  - DJANGO=1.7.11 MIGRATE='./manage.py migrate'
+  - DJANGO=1.8.7 MIGRATE='./manage.py migrate'
+  - DJANGO=1.9 MIGRATE='./manage.py migrate'
+
+matrix:
+  allow_failures:
+    - env: DJANGO=1.9 MIGRATE='./manage.py migrate'
+      python: 2.7
+    - env: DJANGO=1.9 MIGRATE='./manage.py migrate'
+      python: 3.3
+    - env: DJANGO=1.9 MIGRATE='./manage.py migrate'
+      python: 3.4
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
   - DJANGO=1.5.12 MIGRATE='true'
   - DJANGO=1.6.11 MIGRATE='true'
   - DJANGO=1.7.11 MIGRATE='./manage.py migrate'
-  - DJANGO=1.8.7 MIGRATE='./manage.py migrate'
-  - DJANGO=1.9 MIGRATE='./manage.py migrate'
+  - DJANGO=1.8.8 MIGRATE='./manage.py migrate'
+  - DJANGO=1.9.1 MIGRATE='./manage.py migrate'
 
 branches:
   only:
@@ -19,7 +19,7 @@ branches:
 matrix:
   exclude:
     # Django 1.9 does not support python 3.3
-    - env: DJANGO=1.9 MIGRATE='./manage.py migrate'
+    - env: DJANGO=1.9.1 MIGRATE='./manage.py migrate'
       python: 3.3
 
 install:

--- a/examples/chatserver/tests/__init__.py
+++ b/examples/chatserver/tests/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-from .test_chatclient import *

--- a/examples/chatserver/tests/test_chatclient.py
+++ b/examples/chatserver/tests/test_chatclient.py
@@ -5,10 +5,10 @@ import requests
 import six
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.sessions.backends.db import SessionStore
-from django.test import LiveServerTestCase, TestCase
+from django.test import LiveServerTestCase
 from django.test.client import RequestFactory
-from django.utils.importlib import import_module
+from importlib import import_module
+
 from websocket import create_connection, WebSocketException
 from ws4redis.django_runserver import application
 from ws4redis.publisher import RedisPublisher

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -2,7 +2,7 @@ Django==1.8.5
 backports.ssl-match-hostname==3.4.0.2
 django-nose==1.4.1
 django-redis-sessions==0.5.0
-django-websocket-redis==0.4.4
+django-websocket-redis==0.4.5
 gevent==1.0.2
 greenlet==0.4.9
 nose==1.3.7

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8.5
+Django==1.8.8
 backports.ssl-match-hostname==3.4.0.2
 django-nose==1.4.1
 django-redis-sessions==0.5.0


### PR DESCRIPTION
Prior to this commit, the tests were running with Django 1.8 because it
is in requirements.txt, which was installed after the specific version
of Django.

This commit inverts that order, allowing the defined version of Django
to be used for testing.