### PR TITLE
Add support for Sec-WebSocket-Protocol header

### DIFF
--- a/examples/chatserver/tests/test_chatclient.py
+++ b/examples/chatserver/tests/test_chatclient.py
@@ -264,3 +264,12 @@ class WebsocketTests(LiveServerTestCase):
             self.assertEqual(value_before, counter.value,
                              'Connection error while closing with {}'.format(status))
 
+    def test_protocol_support(self):
+        protocol = 'unittestprotocol'
+        websocket_url = self.websocket_base_url + u'?subscribe-broadcast&publish-broadcast'
+        ws = create_connection(websocket_url, subprotocols=[protocol])
+        self.assertTrue(ws.connected)
+        self.assertIn('sec-websocket-protocol', ws.headers)
+        self.assertEqual(protocol, ws.headers['sec-websocket-protocol'])
+        ws.close()
+        self.assertFalse(ws.connected)

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -9,4 +9,4 @@ nose==1.3.7
 redis==2.10.3
 requests==2.7.0
 six==1.10.0
-websocket-client==0.20.0
+websocket-client==0.35.0

--- a/ws4redis/django_runserver.py
+++ b/ws4redis/django_runserver.py
@@ -50,6 +50,7 @@ class WebsocketRunServer(WebsocketWSGIServer):
             ('Connection', 'Upgrade'),
             ('Sec-WebSocket-Accept', sec_ws_accept),
             ('Sec-WebSocket-Version', str(websocket_version)),
+            ('Sec-WebSocket-Protocol', environ.get('HTTP_SEC_WEBSOCKET_PROTOCOL', '')),
         ]
         logger.debug('WebSocket request accepted, switching protocols')
         start_response(force_str('101 Switching Protocols'), headers)


### PR DESCRIPTION
This branch adds support for the Sec-WebSocket-Protocol header. Without this change, the websocket will fail to connect if the Sec-WebSocket-Protocol header is uses by the client.