### PR TITLE
-add Sec-WebSocket-Protocol to header only if it exists in request he…

### DIFF
--- a/ws4redis/django_runserver.py
+++ b/ws4redis/django_runserver.py
@@ -49,9 +49,11 @@ class WebsocketRunServer(WebsocketWSGIServer):
             ('Upgrade', 'websocket'),
             ('Connection', 'Upgrade'),
             ('Sec-WebSocket-Accept', sec_ws_accept),
-            ('Sec-WebSocket-Version', str(websocket_version)),
-            ('Sec-WebSocket-Protocol', environ.get('HTTP_SEC_WEBSOCKET_PROTOCOL', '')),
+            ('Sec-WebSocket-Version', str(websocket_version))
         ]
+        if environ.get('HTTP_SEC_WEBSOCKET_PROTOCOL') != None:
+            headers.append('Sec-WebSocket-Protocol', environ.get('HTTP_SEC_WEBSOCKET_PROTOCOL'))
+
         logger.debug('WebSocket request accepted, switching protocols')
         start_response(force_str('101 Switching Protocols'), headers)
         six.get_method_self(start_response).finish_content()


### PR DESCRIPTION
-add Sec-WebSocket-Protocol to header only if it exists in request header.

When I use Chrome browser for the example project, some times Chrome prompted:
Error during WebSocket handshake: Response must not include 'Sec-WebSocket-Protocol' header if not present in request

and according to the WebSocket spec:
   The Sec-WebSocket-Protocol header field is used in the WebSocket
   opening handshake.  It is sent from the client to the server and back
   from the server to the client to confirm the subprotocol of the
   connection.  This enables scripts to both select a subprotocol and be
   sure that the server agreed to serve that subprotocol.