### PR TITLE
Include documentation in source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include README.md
 include setup.py
 recursive-include ws4redis *.py
 recursive-include ws4redis/static *
+recursive-include docs Makefile conf.py requirements.txt *.rst *.png


### PR DESCRIPTION
This allows distribution packages (e.g. Debian) to build the
documentation from source with only the pypi source tarball.