### PR TITLE
Making WS4REDIS_ALLOWED_CHANNELS accept strings

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -128,6 +128,10 @@ Ensure that your template context contains at least these processors:
 	    ...
 	)
 
+**Websocket for Redis** allows each client to subscribe and to publish on every possible
+channel. To restrict and control access, the ``WS4REDIS_ALLOWED_CHANNELS`` options should
+be set to a callback function anywhere inside your project. See the example and warnings in
+:ref:`SafetyConsiderations`.
 
 Check your Installation
 -----------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -63,12 +63,12 @@ and access the Websocket code:
 	        receive_message: receiveMessage,
 	        heartbeat_msg: {{ WS4REDIS_HEARTBEAT }}
 	    });
-	
+
 	    // attach this function to an event handler on your site
 	    function sendMessage() {
 	        ws4redis.send_message('A message');
 	    }
-	
+
 	    // receive a message though the websocket from the server
 	    function receiveMessage(msg) {
 	        alert('Message from Websocket: ' + msg);
@@ -114,7 +114,7 @@ message to all clients listening on the named facility, referred here as ``fooba
 
 	from ws4redis.publisher import RedisPublisher
 	from ws4redis.redis_store import RedisMessage
-	
+
 	redis_publisher = RedisPublisher(facility='foobar', broadcast=True)
 	message = RedisMessage('Hello World')
 	# and somewhere else
@@ -157,7 +157,7 @@ group where this user is member of.
 .. code-block:: python
 
 	redis_publisher = RedisPublisher(facility='foobar', groups=['chatters'])
-	
+
 	# and somewhere else
 	redis_publisher.publish_message('Hello World')
 
@@ -191,7 +191,7 @@ In this context the the magic item ``SELF`` refers to all clients owning the sam
 
 Publish for Broadcast, User, Group and Session
 ----------------------------------------------
-A Websocket initialized with the URL ``ws://www.example.com/ws/foobar?publish-broadcast``, 
+A Websocket initialized with the URL ``ws://www.example.com/ws/foobar?publish-broadcast``,
 ``ws://www.example.com/ws/foobar?publish-user`` or ``ws://www.example.com/ws/foobar?publish-session``
 will publish a message sent through the Websocket on the named Redis channel ``broadcast:foobar``,
 ``user:john:foobar`` and ``session:wnqd0gbw5obpnj50zwh6yaq2yz4o8g9x:foobar`` respectively.
@@ -207,7 +207,7 @@ whenever it requires them.
 	# if the publisher is required only for fetching messages, use an
 	# empty constructor, otherwise reuse an existing redis_publisher
 	redis_publisher = RedisPublisher()
-	
+
 	# and somewhere else
 	facility = 'foobar'
 	audience = 'any'
@@ -241,6 +241,8 @@ the client, immediately after he connects to the server.
 .. note:: By using client code, which automatically reconnects after the Websocket closes, one can
           create a setup which is immune against server and client reboots.
 
+.. _SafetyConsiderations:
+
 Safety considerations
 ---------------------
 The default setting of **Websocket for Redis** is to allow each client to subscribe and to publish
@@ -264,7 +266,7 @@ Disallow non authenticated users to subscribe or to publish on the Websocket:
 .. code-block:: python
 
 	from django.core.exceptions import PermissionDenied
-	
+
 	def get_allowed_channels(request, channels):
 	    if not request.user.is_authenticated():
 	        raise PermissionDenied('Not allowed to subscribe nor to publish on the Websocket!')

--- a/examples/chatserver/tests/test_chatclient.py
+++ b/examples/chatserver/tests/test_chatclient.py
@@ -240,7 +240,7 @@ class WebsocketTests(LiveServerTestCase):
 
         callbacks = [denied_channels, 'chatserver.tests.denied_channels.denied_channels']
         for callback in callbacks:
-            private_settings.WS4REDIS_ALLOWED_CHANNELS = denied_channels
+            private_settings.WS4REDIS_ALLOWED_CHANNELS = callback
             try:
                 ws = create_connection(websocket_url, header=['Deny-Channels: YES'])
                 self.fail('Did not reject channels')

--- a/examples/chatserver/tests/test_chatclient.py
+++ b/examples/chatserver/tests/test_chatclient.py
@@ -11,10 +11,12 @@ from importlib import import_module
 
 from django.core.servers.basehttp import WSGIServer
 from websocket import create_connection, WebSocketException
+from ws4redis import settings as private_settings
 from ws4redis.django_runserver import application
 from ws4redis.publisher import RedisPublisher
 from ws4redis.redis_store import RedisMessage, SELF
 
+from .denied_channels import denied_channels
 
 if six.PY3:
     unichr = chr
@@ -230,12 +232,22 @@ class WebsocketTests(LiveServerTestCase):
         self.assertEqual(pub2._publishers, set([self.prefix + ':user:john:' + self.facility]))
 
     def test_forbidden_channel(self):
+        private_settings.WS4REDIS_ALLOWED_CHANNELS = None
         websocket_url = self.websocket_base_url + u'?subscribe-broadcast&publish-broadcast'
-        try:
-            create_connection(websocket_url, header=['Deny-Channels: YES'])
-            self.fail('Did not reject channels')
-        except WebSocketException:
-            self.assertTrue(True)
+        ws = create_connection(websocket_url, header=['Deny-Channels: YES'])
+        self.assertTrue(True)  # Passes because all channels allowed.
+        ws.close()
+
+        callbacks = [denied_channels, 'chatserver.tests.denied_channels.denied_channels']
+        for callback in callbacks:
+            private_settings.WS4REDIS_ALLOWED_CHANNELS = denied_channels
+            try:
+                ws = create_connection(websocket_url, header=['Deny-Channels: YES'])
+                self.fail('Did not reject channels')
+            except WebSocketException:
+                self.assertTrue(True)
+            finally:
+                ws.close()
 
     def test_close_connection(self):
 


### PR DESCRIPTION
Small patch for `wsgi_server.py` to ensure that users can set `WS4REDIS_ALLOWED_CHANNELS` to a module string as common in most django applications.

Modified UnitTests accordingly and added the setting into configuration docs.