### PR TITLE
Fix deadlock condition for subscriber-only client

### DIFF
--- a/ws4redis/websocket.py
+++ b/ws4redis/websocket.py
@@ -178,10 +178,10 @@ class WebSocket(object):
                     raise WebSocketError("Unexpected frame with opcode=0")
             elif f_opcode == self.OPCODE_PING:
                 self.handle_ping(header, payload)
-                continue
+                return
             elif f_opcode == self.OPCODE_PONG:
                 self.handle_pong(header, payload)
-                continue
+                return
             elif f_opcode == self.OPCODE_CLOSE:
                 self.handle_close(header, payload)
                 return


### PR DESCRIPTION
WebsocketWSGIServer.**call** may block indefinitely if client sends
PING opcode but nothing after it. PING opcode causes select to
siganl activity on websocket_fd, subsequent call to Websocket.receive
reads PING frame and continues to wait for actual data frame. If
client is subscriber-only and sends only PINGs, this data never comes
and Websocket.receiver does not return until client closes its end.
