### PR TITLE
Exposes WebSocket readyState in WS4Redis

### DIFF
--- a/ws4redis/static/js/ws4redis.js
+++ b/ws4redis/static/js/ws4redis.js
@@ -102,4 +102,9 @@ function WS4Redis(options, $) {
 	this.send_message = function(message) {
 		ws.send(message);
 	};
+	
+	this.get_state = function() {
+		return ws.readyState;	
+	};
+	
 }


### PR DESCRIPTION
To be able to act on socket state this adds a method that returns readyState of the internally used WebSocket.