### PR TITLE
Adding support to cross domains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ intended to work under [uWSGI](http://projects.unbit.it/uwsgi/) and behind [NGiN
 or [Apache](http://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html) version 2.4.5 or later.
 
 
-New in 0.4.6
+New in 0.5.1
 ------------
-* Added support for the Sec-WebSocket-Protocol header. Thanks to Erwin Junge.
-* Fixed bug in unpacking binary websocket protocol.
+Installation settings:
+
+* Adding support to run websockets in cross domains (setting WEBSOCKET_HOST).
+
 
 
 Features

--- a/README.md
+++ b/README.md
@@ -15,15 +15,10 @@ intended to work under [uWSGI](http://projects.unbit.it/uwsgi/) and behind [NGiN
 or [Apache](http://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html) version 2.4.5 or later.
 
 
-New in 0.4.5
+New in 0.4.6
 ------------
-* Created 1 requirements file under ``examples/chatserver/requirements.txt``.
-* Renamed chatclient.py to test_chatclient.py - for django-nose testrunner.
-* Migrated example project to django 1.7.
-* Edited ``docs/testing.rst`` to show new changes for using example project.
-* Added support for Python 3.3 and 3.4.
-* Added support for Django-1.8
-* Removes the check for middleware by name.
+* Added support for the Sec-WebSocket-Protocol header. Thanks to Erwin Junge.
+* Fixed bug in unpacking binary websocket protocol.
 
 
 Features

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,8 @@ Release History
 
 0.4.7
 -----
+* Adding support to run websockets in cross domains (setting WEBSOCKET_HOST).
+
 Improvements to the javascript API:
 
 * Performing reconnection attempts when the first connection (on instantiation) fails.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@
 Release History
 ===============
 
+0.5.1
+-----
+Installation settings:
+
+* Adding support to run websockets in cross domains (setting WEBSOCKET_HOST).
+
 0.5.0
 -----
 * Support for Django-1.11.
@@ -14,10 +20,6 @@ Release History
 
 0.4.7
 -----
-Installation settings:
-
-* Adding support to run websockets in cross domains (setting WEBSOCKET_HOST).
-
 Improvements to the javascript API:
 
 * Performing reconnection attempts when the first connection (on instantiation) fails.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,8 +14,7 @@ Release History
 
 0.4.7
 -----
-
-Instalation settings:
+Installation settings:
 
 * Adding support to run websockets in cross domains (setting WEBSOCKET_HOST).
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,9 @@ Release History
 
 0.4.7
 -----
+
+Instalation settings:
+
 * Adding support to run websockets in cross domains (setting WEBSOCKET_HOST).
 
 Improvements to the javascript API:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -142,6 +142,15 @@ channel. To restrict and control access, the ``WS4REDIS_ALLOWED_CHANNELS`` optio
 be set to a callback function anywhere inside your project. See the example and warnings in
 :ref:`SafetyConsiderations`.
 
+Running Websockets in Cross Domains
+-----------------------------------
+In case you wish to listen to websocket connections in a cross domain (websocket domain name != site domain name), use the setting WEBSOCKET_HOST. However, it is mandatory to provide the Django setting SESSION_COOKIE_DOMAIN in order to tell Django to use the some cookie for both domains. If WEBSOCKET_HOST is not provided, it will be used the site domain (request.get_host()).
+
+.. code-block:: python
+
+	WEBSOCKET_HOST = 'ws.myapp.com' # Change this according to your needs.
+	SESSION_COOKIE_DOMAIN = '.myapp.com' # Change this according to your needs.
+
 Check your Installation
 -----------------------
 With **Websockets for Redis** your Django application has immediate access to code written for

--- a/ws4redis/context_processors.py
+++ b/ws4redis/context_processors.py
@@ -7,10 +7,11 @@ def default(request):
     """
     Adds additional context variables to the default context.
     """
+    host = settings.WEBSOCKET_HOST or request.get_host()
     protocol = request.is_secure() and 'wss://' or 'ws://'
     heartbeat_msg = settings.WS4REDIS_HEARTBEAT and '"{0}"'.format(settings.WS4REDIS_HEARTBEAT) or 'null'
     context = {
-        'WEBSOCKET_URI': protocol + request.get_host() + settings.WEBSOCKET_URL,
+        'WEBSOCKET_URI': protocol + host + settings.WEBSOCKET_URL,
         'WS4REDIS_HEARTBEAT': mark_safe(heartbeat_msg),
     }
     return context

--- a/ws4redis/settings.py
+++ b/ws4redis/settings.py
@@ -3,6 +3,12 @@ from django.conf import settings
 
 WEBSOCKET_URL = getattr(settings, 'WEBSOCKET_URL', '/ws/')
 
+"""
+The host addres that will be listening for Websocket connections. If not provided,
+it will be used the same host as of the site.
+"""
+WEBSOCKET_HOST = getattr(settings, 'WEBSOCKET_HOST', None)
+
 WS4REDIS_CONNECTION = getattr(settings, 'WS4REDIS_CONNECTION', {
     'host': 'localhost',
     'port': 6379,


### PR DESCRIPTION
It was added the setting WEBSOCKET_HOST. This enables using websockets in cross domains. This is, the websocket domain (e.g. ws.myapp.com) is different from the site domain (e.g. www.myapp.com). However, it is mandatory to provide the Django setting SESSION_COOKIE_DOMAIN (e.g. SESSION_COOKIE_DOMAIN = '.myapp.com'). This pull request is backwards compatible. Documentation and changelog were updated accordingly.
