### PR TITLE
make is_authenticated compatible with Django 1.10

### DIFF
--- a/ws4redis/_compat.py
+++ b/ws4redis/_compat.py
@@ -1,0 +1,13 @@
+def is_authenticated(request):
+    """Wrapper for checking when a request is authenticated. This checks first
+    for a valid request and user, then checks to see if `is_authenticated` is
+    a callable in order to be compatible with Django 1.10, wherein using a
+    callable for `is_authenticated` is deprecated in favor of a property.
+    """
+    if not request:
+        return False
+    if not request.user:
+        return False
+    if callable(request.user.is_authenticated):
+        return request.user.is_authenticated()
+    return request.user.is_authenticated

--- a/ws4redis/publisher.py
+++ b/ws4redis/publisher.py
@@ -2,6 +2,7 @@
 from redis import ConnectionPool, StrictRedis
 from ws4redis import settings
 from ws4redis.redis_store import RedisStore
+from ws4redis._compat import is_authenticated
 
 redis_connection_pool = ConnectionPool(**settings.WS4REDIS_CONNECTION)
 
@@ -32,11 +33,11 @@ class RedisPublisher(RedisStore):
             if request and request.session:
                 channels.append('{prefix}session:{0}:{facility}'.format(request.session.session_key, prefix=prefix, facility=facility))
         if audience in ('user', 'any',):
-            if request and request.user and request.user.is_authenticated():
+            if is_authenticated(request):
                 channels.append('{prefix}user:{0}:{facility}'.format(request.user.get_username(), prefix=prefix, facility=facility))
         if audience in ('group', 'any',):
             try:
-                if request.user.is_authenticated():
+                if is_authenticated(request):
                     groups = request.session['ws4redis:memberof']
                     channels.extend('{prefix}group:{0}:{facility}'.format(g, prefix=prefix, facility=facility)
                                 for g in groups)

--- a/ws4redis/redis_store.py
+++ b/ws4redis/redis_store.py
@@ -2,6 +2,7 @@
 import six
 import warnings
 from ws4redis import settings
+from ws4redis._compat import is_authenticated
 
 
 """
@@ -18,7 +19,7 @@ def _wrap_users(users, request):
     """
     result = set()
     for u in users:
-        if u is SELF and request and request.user and request.user.is_authenticated():
+        if u is SELF and is_authenticated(request):
             result.add(request.user.get_username())
         else:
             result.add(u)
@@ -36,7 +37,7 @@ def _wrap_groups(groups, request):
     """
     result = set()
     for g in groups:
-        if g is SELF and request and request.user and request.user.is_authenticated():
+        if g is SELF and is_authenticated(request):
             result.update(request.session.get('ws4redis:memberof', []))
         else:
             result.add(g)
@@ -129,7 +130,7 @@ class RedisStore(object):
             # message is delivered to all listed groups
             channels.extend('{prefix}group:{0}:{facility}'.format(g, prefix=prefix, facility=facility)
                             for g in _wrap_groups(groups, request))
-        elif groups is True and request and request.user and request.user.is_authenticated():
+        elif groups is True and is_authenticated(request):
             # message is delivered to all groups the currently logged in user belongs to
             warnings.warn('Wrap groups=True into a list or tuple using SELF', DeprecationWarning)
             channels.extend('{prefix}group:{0}:{facility}'.format(g, prefix=prefix, facility=facility)
@@ -146,7 +147,7 @@ class RedisStore(object):
             # message is delivered to all listed users
             channels.extend('{prefix}user:{0}:{facility}'.format(u, prefix=prefix, facility=facility)
                             for u in _wrap_users(users, request))
-        elif users is True and request and request.user and request.user.is_authenticated():
+        elif users is True and is_authenticated(request):
             # message is delivered to browser instances of the currently logged in user
             warnings.warn('Wrap users=True into a list or tuple using SELF', DeprecationWarning)
             channels.append('{prefix}user:{0}:{facility}'.format(request.user.get_username(), prefix=prefix, facility=facility))


### PR DESCRIPTION
Django 1.10 deprecates callable `is_authenticated` (among other methods) in favor of using properties. This change introduces a function to check whether a request is authenticated and also make it forward-compatible with Django 1.10 and later.