### PR TITLE
Enabled use of unix sockets for Redis connection

### DIFF
--- a/ws4redis/publisher.py
+++ b/ws4redis/publisher.py
@@ -4,15 +4,13 @@ from ws4redis import settings
 from ws4redis.redis_store import RedisStore
 from ws4redis._compat import is_authenticated
 
-redis_connection_pool = ConnectionPool(**settings.WS4REDIS_CONNECTION)
-
 
 class RedisPublisher(RedisStore):
     def __init__(self, **kwargs):
         """
         Initialize the channels for publishing messages through the message queue.
         """
-        connection = StrictRedis(connection_pool=redis_connection_pool)
+        connection = StrictRedis(**settings.WS4REDIS_CONNECTION)
         super(RedisPublisher, self).__init__(connection)
         for key in self._get_message_channels(**kwargs):
             self._publishers.add(key)


### PR DESCRIPTION
Switched StrictRedis instantiation to settings parameters. Unix sockets can be enabled by providing following WS4REDIS_CONNECTION configuration:

``
WS4REDIS_CONNECTION = {
    'unix_socket_path': '/path/to/redis.sock'
}
``