### PR TITLE
fix #222

### DIFF
--- a/ws4redis/django_runserver.py
+++ b/ws4redis/django_runserver.py
@@ -1,4 +1,5 @@
 #-*- coding: utf-8 -*-
+import logging
 import six
 import base64
 import select
@@ -6,7 +7,6 @@ from hashlib import sha1
 from wsgiref import util
 from django.core.wsgi import get_wsgi_application
 from django.core.servers.basehttp import WSGIServer, WSGIRequestHandler
-from django.core.handlers.wsgi import logger
 from django.conf import settings
 from django.core.management.commands import runserver
 from django.utils.six.moves import socketserver
@@ -15,6 +15,8 @@ from ws4redis.websocket import WebSocket
 from ws4redis.wsgi_server import WebsocketWSGIServer, HandshakeError, UpgradeRequiredError
 
 util._hoppish = {}.__contains__
+
+logger = logging.getLogger('django.request')
 
 
 class WebsocketRunServer(WebsocketWSGIServer):


### PR DESCRIPTION
gets the logger directly instead of relying on django implementation details

reference: https://github.com/django/django/blob/1.10.6/django/core/handlers/wsgi.py#L19