### PR TITLE
Close #119

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -200,7 +200,7 @@ Configuration section for Apache:
 .. code-block:: guess
 
 	<VirtualHost IPADDR:80>
-	    ProxyPass    /ws/    ws://127.0.0.1:9090/
+	    ProxyPass    /ws/    ws://127.0.0.1:9090/ws/
 	</VirtualHost>
 
 


### PR DESCRIPTION
Following the instructions from RTD and the example packaged with the code did not work.
Following the instructions from https://github.com/jrief/django-websocket-redis/issues/119#issuecomment-167718471 did work.

Althought using Apache with django-websocket-redis is not the optimal configuration, the instructios should still be updated to reflect correct values.