### PR TITLE
Publisher: allow overriding default connection

### DIFF
--- a/ws4redis/publisher.py
+++ b/ws4redis/publisher.py
@@ -15,11 +15,12 @@ else:
     redis_connection_pool = ConnectionPool(**settings.WS4REDIS_CONNECTION)
 
 class RedisPublisher(RedisStore):
-    def __init__(self, **kwargs):
+    def __init__(self, connection = None, **kwargs):
         """
         Initialize the channels for publishing messages through the message queue.
         """
-        connection = StrictRedis(connection_pool=redis_connection_pool)
+        if connection == None:
+            connection = StrictRedis(connection_pool=redis_connection_pool)
         super(RedisPublisher, self).__init__(connection)
         for key in self._get_message_channels(**kwargs):
             self._publishers.add(key)


### PR DESCRIPTION
This can for example be used for pipelining