### PR TITLE
Issue #284 Handle ssl connections

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -82,6 +82,15 @@ override these values
 
 .. note:: Specify only the values, which deviate from the default.
 
+If your Redis instance requires a SSL connection, set the ``ssl`` flag to ``True``: 
+
+.. code-block:: python
+
+	WS4REDIS_CONNECTION = {
+	    ...
+	    'ssl': True
+	}
+
 If your Redis instance is accessed via a Unix Domain Socket, you can configure that as well:
 
 .. code-block:: python


### PR DESCRIPTION
* `RedisPublisher` handles `ssl` flag
* Update docs

Btw, i've used [black](https://github.com/ambv/black) for the small parts i've changed. Have you considered using this tool. It really reduces time spent on code formatting and let developers focus on what matters.

In terms of testing, afaik [travis](https://docs.travis-ci.com/user/database-setup/#redis) does not support natively ssl redis-servers. Since modifications relies on well-tested code (`redis.SSLConnection`), i guess it's ok not to test it thoroughly.