### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -287,7 +287,7 @@ Serving static files
 --------------------
 The alert reader will have noticed, that static files are not handled by this configuration. While
 in theory it is possible to configure **uWSGI** to `deliver static files`_, please note that
-**uWSGI** is not intended to completly `replace a webserver`_. Therefore, before adding
+**uWSGI** is not intended to completely `replace a webserver`_. Therefore, before adding
 ``route = ^/static static:/path/to/static/root`` to the emperors ini-file, consider to place them
 onto a Content Delivery Network, such as Amazon S3.
 

--- a/ws4redis/static/js/ws4redis.js
+++ b/ws4redis/static/js/ws4redis.js
@@ -76,7 +76,7 @@ function WS4Redis(options, $) {
 
 	function on_open() {
 		console.log('Connected!');
-		// new connection, reset attemps counter
+		// new connection, reset attempts counter
 		attempts = 1;
 		deferred.resolve();
 		if (opts.heartbeat_msg && heartbeat_interval === null) {
@@ -113,7 +113,7 @@ function WS4Redis(options, $) {
 	// this code is borrowed from http://blog.johnryding.com/post/78544969349/
 	//
 	// Generate an interval that is randomly between 0 and 2^k - 1, where k is
-	// the number of connection attmpts, with a maximum interval of 30 seconds,
+	// the number of connection attempts, with a maximum interval of 30 seconds,
 	// so it starts at 0 - 1 seconds and maxes out at 0 - 30 seconds
 	function generate_inteval(k) {
 		var maxInterval = (Math.pow(2, k) - 1) * 1000;


### PR DESCRIPTION
There are small typos in:
- docs/running.rst
- ws4redis/static/js/ws4redis.js

Fixes:
- Should read `completely` rather than `completly`.
- Should read `attempts` rather than `attmpts`.
- Should read `attempts` rather than `attemps`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md