### PR TITLE
Update django_runserver.py

### DIFF
--- a/ws4redis/django_runserver.py
+++ b/ws4redis/django_runserver.py
@@ -98,7 +98,7 @@ class WebsocketRunServer(WebsocketWSGIServer):
         logger.debug('WebSocket request accepted, switching protocols')
         start_response(force_str('101 Switching Protocols'), headers)
         six.get_method_self(start_response).finish_content()
-        if (django.VERSION[:3] >= (2,1,5)):
+        if (2, 1, 5) <= django.VERSION[:3] < (4, 2, 0):
             wsgi_input = environ['wsgi.input'].stream
         else:
             wsgi_input = environ['wsgi.input']


### PR DESCRIPTION
`stream` attribute of `LimitedStream` was removed from `core.handlers.wsgi `in Django 4
Please refer to this file: https://github.com/django/django/commit/b47f2f5b907732d80b164f1f361ae39da94a3fa6